### PR TITLE
Kerning support

### DIFF
--- a/ext/import-font.cpp
+++ b/ext/import-font.cpp
@@ -169,7 +169,7 @@ bool getKerning(double &output, FontHandle *font, int unicode1, int unicode2) {
         output = 0;
         return false;
     }
-    output = kerning.x/64.;
+    output = unitScale * kerning.x/64.;
     return true;
 }
 


### PR DESCRIPTION
Added kerning support to the playcanvas fork of msdfgen.

The converter takes one or more '-kerning #char' command line argument pairs. The resulting kerning information (if any) is written to stdout along with the other metrics information in the following format:
kerning #char = number