### PR TITLE
[FIX] change link on Valve paper

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 This is a utility for generating signed distance fields from vector shapes and font glyphs,
 which serve as a texture representation that can be used in real-time graphics to efficiently reproduce said shapes.
 Although it can also be used to generate conventional signed distance fields best known from
-[this Valve paper](http://www.valvesoftware.com/publications/2007/SIGGRAPH2007_AlphaTestedMagnification.pdf)
+[this Valve paper](https://steamcdn-a.akamaihd.net/apps/valve/2007/SIGGRAPH2007_AlphaTestedMagnification.pdf)
 and pseudo-distance fields, its primary purpose is to generate multi-channel distance fields,
 using a method I have developed. Unlike monochrome distance fields, they have the ability
 to reproduce sharp corners almost perfectly by utilizing all three color channels.


### PR DESCRIPTION
Link on Valve paper not available. I found another link, i thing it's link correct. 

Old link: http://www.valvesoftware.com/publications/2007/SIGGRAPH2007_AlphaTestedMagnification.pdf
![image](https://user-images.githubusercontent.com/17799857/101993911-cfa7bd80-3cc6-11eb-9a16-4d2f92378a67.png)

Updated link: https://steamcdn-a.akamaihd.net/apps/valve/2007/SIGGRAPH2007_AlphaTestedMagnification.pdf
![image](https://user-images.githubusercontent.com/17799857/101993898-bdc61a80-3cc6-11eb-8797-c3410f570be1.png)

